### PR TITLE
fix: downgraded go version to match dev machine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.20-alpine3.17 AS builder
+FROM golang:1.19-alpine3.17 AS builder
 WORKDIR /app
-RUN apk add --no-cache just
+RUN apk add --no-cache just gcc libc-dev
 
 FROM builder as build1
 COPY . /app


### PR DESCRIPTION
Used the docker image using the following command, but got a panic. This is due to a mismatch golang version in the Docker image and development machine.
 
```
podman run -it --rm --name "polygon-fetcher" -p 80:80 -v ./data:/data fjctp/polygon-fetcher:latest
```

![image](https://user-images.githubusercontent.com/4595933/236638850-f170fa28-dadb-4903-bee7-749e05826323.png)
